### PR TITLE
feat: sync paddings values with page-constructor indents values

### DIFF
--- a/src/blocks/Layout/Layout.tsx
+++ b/src/blocks/Layout/Layout.tsx
@@ -36,8 +36,8 @@ export const Layout = ({
     fullWidth,
     mobileOrder,
     children,
-    paddingTop = 'xs',
-    paddingBottom = 'xs',
+    paddingTop = '0',
+    paddingBottom = '0',
 }: PropsWithChildren<LayoutProps>) => {
     const layout: LayoutType = useMemo(() => {
         const layoutConfig: LayoutType = {

--- a/src/components/Wrapper/Wrapper.tsx
+++ b/src/components/Wrapper/Wrapper.tsx
@@ -24,7 +24,7 @@ export const Wrapper: React.FunctionComponent<WrapperProps> = ({
     <section
         className={b(
             {
-                ['padding-top']: paddings?.top || 'xs',
+                ['padding-top']: paddings?.top || '0',
                 ['padding-bottom']: paddings?.bottom || 'l',
                 ['padding-left']: paddings?.left || '',
                 ['padding-right']: paddings?.right || '',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,5 +33,5 @@ export enum BlogMetrikaGoalIds {
 
 export const DEFAULT_PADDINGS: Paddings = {
     [PaddingsDirections.bottom]: 'l',
-    [PaddingsDirections.top]: 'xs',
+    [PaddingsDirections.top]: '0',
 };

--- a/src/models/paddings.ts
+++ b/src/models/paddings.ts
@@ -5,7 +5,7 @@ export enum PaddingsDirections {
     right = 'right',
 }
 
-export type PaddingSize = 'xs' | 's' | 'm' | 'l' | 'xl';
+export type PaddingSize = '0' | 'xs' | 's' | 'm' | 'l' | 'xl';
 
 export type Paddings = {
     [key in PaddingsDirections]?: PaddingSize;

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -4,12 +4,16 @@
 
 @mixin paddings() {
     &_padding-top {
+        &_0 {
+            padding-top: 0;
+        }
+
         &_xs {
-            padding-top: 0px;
+            padding-top: $indentXS;
         }
 
         &_s {
-            padding-top: $indentXS;
+            padding-top: $indentSM;
         }
 
         &_m {
@@ -26,12 +30,16 @@
     }
 
     &_padding-bottom {
+        &_0 {
+            padding-bottom: 0;
+        }
+
         &_xs {
-            padding-bottom: 0px;
+            padding-bottom: $indentXS;
         }
 
         &_s {
-            padding-bottom: $indentXS;
+            padding-bottom: $indentSM;
         }
 
         &_m {

--- a/test-utils/constants.ts
+++ b/test-utils/constants.ts
@@ -1,5 +1,5 @@
 import {PaddingSize} from '../src/models/paddings';
 
-export const PADDING_SIZES: PaddingSize[] = ['xs', 's', 'm', 'l', 'xl'];
+export const PADDING_SIZES: PaddingSize[] = ['0', 'xs', 's', 'm', 'l', 'xl'];
 
 export const ERROR_INPUT_DATA_MESSAGE = 'There are errors in input test data';


### PR DESCRIPTION
sync paddings with PC indents

Migrated:

`xs` old -> `0` new
`s` old -> `xs` new

and add value `s` with `{ padding-top: $indentSM }`